### PR TITLE
Upgrade Android NDK to version 27.0.12077973

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -87,7 +87,7 @@ jobs:
             target: i686-linux-android
             setup_env: |
               set -x
-              ANDROID_NDK_HOME=$ANDROID_HOME/ndk/25.2.9519653
+              ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.0.12077973
               CC=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android21-clang
 
               echo "CC=$CC" >> $GITHUB_ENV
@@ -95,14 +95,13 @@ jobs:
               echo "CLANG_PATH=$CC" >> $GITHUB_ENV
               echo "CARGO_TARGET_I686_LINUX_ANDROID_LINKER=$CC" >> $GITHUB_ENV
 
-              echo "LIBCLANG_PATH=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/lib64/libclang.so.13" >> $GITHUB_ENV
               echo "LLVM_CONFIG_PATH=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-config" >> $GITHUB_ENV
               echo "BINDGEN_EXTRA_CLANG_ARGS='-isysroot $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot'" >> $GITHUB_ENV
           - name: android-x86_64
             target: x86_64-linux-android
             setup_env: |
               set -x
-              ANDROID_NDK_HOME=$ANDROID_HOME/ndk/25.2.9519653
+              ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.0.12077973
               CC=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android21-clang
 
               echo "CC=$CC" >> $GITHUB_ENV
@@ -110,14 +109,13 @@ jobs:
               echo "CLANG_PATH=$CC" >> $GITHUB_ENV
               echo "CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=$CC" >> $GITHUB_ENV
 
-              echo "LIBCLANG_PATH=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/lib64/libclang.so.13" >> $GITHUB_ENV
               echo "LLVM_CONFIG_PATH=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-config" >> $GITHUB_ENV
               echo "BINDGEN_EXTRA_CLANG_ARGS='-isysroot $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot'" >> $GITHUB_ENV
           - name: android-aarch64
             target: aarch64-linux-android
             setup_env: |
               set -x
-              ANDROID_NDK_HOME=$ANDROID_HOME/ndk/25.2.9519653
+              ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.0.12077973
               CC=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang
 
               echo "CC=$CC" >> $GITHUB_ENV
@@ -125,14 +123,13 @@ jobs:
               echo "CLANG_PATH=$CC" >> $GITHUB_ENV
               echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=$CC" >> $GITHUB_ENV
 
-              echo "LIBCLANG_PATH=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/lib64/libclang.so.13" >> $GITHUB_ENV
               echo "LLVM_CONFIG_PATH=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-config" >> $GITHUB_ENV
               echo "BINDGEN_EXTRA_CLANG_ARGS='-isysroot $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot'" >> $GITHUB_ENV
           - name: android-armv7
             target: armv7-linux-androideabi
             setup_env: |
               set -x
-              ANDROID_NDK_HOME=$ANDROID_HOME/ndk/25.2.9519653
+              ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.0.12077973
               CC=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi21-clang
 
               echo "CC=$CC" >> $GITHUB_ENV
@@ -140,7 +137,6 @@ jobs:
               echo "CLANG_PATH=$CC" >> $GITHUB_ENV
               echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=$CC" >> $GITHUB_ENV
 
-              echo "LIBCLANG_PATH=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/lib64/libclang.so.13" >> $GITHUB_ENV
               echo "LLVM_CONFIG_PATH=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-config" >> $GITHUB_ENV
               echo "BINDGEN_EXTRA_CLANG_ARGS='-isysroot $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot'" >> $GITHUB_ENV
     env:


### PR DESCRIPTION
Updated the Android NDK version from 25.2.9519653 to 27.0.12077973 across all target architectures in the GitHub Actions CI/CD pipeline. This change ensures compatibility with the latest NDK features and improvements. The `LIBCLANG_PATH` environment variable was also removed as it was no longer being utilized.